### PR TITLE
fix: resolve vocabulary path relative to server

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -53,7 +53,7 @@ export class MemStorage implements IStorage {
       // Load vocabulary from JSON file
       const fs = await import('fs');
       const path = await import('path');
-      const vocabPath = path.join(process.cwd(), 'client/src/data/spanish_vocab.json');
+      const vocabPath = path.resolve(__dirname, '../client/src/data/spanish_vocab.json');
       const vocabData = JSON.parse(fs.readFileSync(vocabPath, 'utf8'));
       
       // Process each theme and its vocabulary items


### PR DESCRIPTION
## Summary
- load spanish vocabulary JSON relative to the server folder so deployment works regardless of working directory

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: tsconfig.json(28,1): error TS1012: Unexpected token)


------
https://chatgpt.com/codex/tasks/task_e_68bb3000bc24832e9b1d5a88cbf698c2