### PR TITLE
refactor: centralize async route error handling

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,119 +1,142 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { insertGameSessionSchema, insertUserProgressSchema } from "@shared/schema";
+import { insertGameSessionSchema } from "@shared/schema";
 import { z } from "zod";
+import asyncHandler from "./utils/asyncHandler";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Get all vocabulary words
-  app.get("/api/vocabulary", async (req, res) => {
-    try {
+  app.get(
+    "/api/vocabulary",
+    asyncHandler(async (_req, res) => {
       const words = await storage.getVocabularyWords();
       res.json(words);
-    } catch (error) {
-      res.status(500).json({ error: "Failed to fetch vocabulary" });
-    }
-  });
+    })
+  );
 
   // Get vocabulary words by category
-  app.get("/api/vocabulary/category/:category", async (req, res) => {
-    try {
+  app.get(
+    "/api/vocabulary/category/:category",
+    asyncHandler(async (req, res) => {
       const { category } = req.params;
       const words = await storage.getVocabularyWordsByCategory(category);
       res.json(words);
-    } catch (error) {
-      res.status(500).json({ error: "Failed to fetch vocabulary by category" });
-    }
-  });
+    })
+  );
 
   // Get user progress
-  app.get("/api/progress/:userId", async (req, res) => {
-    try {
+  app.get(
+    "/api/progress/:userId",
+    asyncHandler(async (req, res) => {
       const { userId } = req.params;
       const progress = await storage.getUserProgress(userId);
       res.json(progress);
-    } catch (error) {
-      res.status(500).json({ error: "Failed to fetch user progress" });
-    }
-  });
+    })
+  );
 
   // Update user progress
-  app.post("/api/progress", async (req, res) => {
-    try {
+  app.post(
+    "/api/progress",
+    asyncHandler(async (req, res) => {
       const updateSchema = z.object({
         userId: z.string(),
         wordId: z.string(),
         correct: z.boolean()
       });
-      
-      const { userId, wordId, correct } = updateSchema.parse(req.body);
+
+      const parsed = updateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        const error: any = new Error("Invalid request data");
+        error.status = 400;
+        throw error;
+      }
+
+      const { userId, wordId, correct } = parsed.data;
       const progress = await storage.updateUserProgress(userId, wordId, correct);
-      
+
       // Update user stats
       const stats = await storage.getUserStats(userId);
       const newStars = stats.totalStars + (correct ? 1 : 0);
-      const newWordsLearned = progress.mastered ? stats.wordsLearned + 1 : stats.wordsLearned;
-      
+      const newWordsLearned = progress.mastered
+        ? stats.wordsLearned + 1
+        : stats.wordsLearned;
+
       await storage.updateUserStats(userId, {
         totalStars: newStars,
         wordsLearned: newWordsLearned,
         lastPlayDate: new Date().toISOString()
       });
-      
+
       res.json(progress);
-    } catch (error) {
-      res.status(400).json({ error: "Invalid request data" });
-    }
-  });
+    })
+  );
 
   // Create game session
-  app.post("/api/game-session", async (req, res) => {
-    try {
-      const sessionData = insertGameSessionSchema.parse(req.body);
-      const session = await storage.createGameSession(sessionData);
+  app.post(
+    "/api/game-session",
+    asyncHandler(async (req, res) => {
+      const parsed = insertGameSessionSchema.safeParse(req.body);
+      if (!parsed.success) {
+        const error: any = new Error("Invalid session data");
+        error.status = 400;
+        throw error;
+      }
+      const session = await storage.createGameSession(parsed.data);
       res.json(session);
-    } catch (error) {
-      res.status(400).json({ error: "Invalid session data" });
-    }
-  });
+    })
+  );
 
   // Update game session
-  app.patch("/api/game-session/:id", async (req, res) => {
-    try {
+  app.patch(
+    "/api/game-session/:id",
+    asyncHandler(async (req, res) => {
       const { id } = req.params;
       const updates = req.body;
-      const session = await storage.updateGameSession(id, updates);
+      const session = await storage
+        .updateGameSession(id, updates)
+        .catch(err => {
+          (err as any).status = 404;
+          throw err;
+        });
       res.json(session);
-    } catch (error) {
-      res.status(404).json({ error: "Game session not found" });
-    }
-  });
+    })
+  );
 
   // Get user stats
-  app.get("/api/stats/:userId", async (req, res) => {
-    try {
+  app.get(
+    "/api/stats/:userId",
+    asyncHandler(async (req, res) => {
       const { userId } = req.params;
       const stats = await storage.getUserStats(userId);
       res.json(stats);
-    } catch (error) {
-      res.status(500).json({ error: "Failed to fetch user stats" });
-    }
-  });
+    })
+  );
 
   // Get game categories with progress
-  app.get("/api/categories/:userId", async (req, res) => {
-    try {
+  app.get(
+    "/api/categories/:userId",
+    asyncHandler(async (req, res) => {
       const { userId } = req.params;
       const allWords = await storage.getVocabularyWords();
       const userProgress = await storage.getUserProgress(userId);
-      
-      const categories = ["greetings", "numbers_1_10", "colors", "animals", "food", "family", "body_parts", "weather"];
+
+      const categories = [
+        "greetings",
+        "numbers_1_10",
+        "colors",
+        "animals",
+        "food",
+        "family",
+        "body_parts",
+        "weather"
+      ];
       const categoryProgress = categories.map(category => {
         const categoryWords = allWords.filter(word => word.category === category);
-        const completedWords = categoryWords.filter(word => 
+        const completedWords = categoryWords.filter(word =>
           userProgress.some(p => p.wordId === word.id && p.mastered)
         );
-        
+
         return {
           name: category,
           total: categoryWords.length,
@@ -121,12 +144,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
           words: categoryWords
         };
       });
-      
+
       res.json(categoryProgress);
-    } catch (error) {
-      res.status(500).json({ error: "Failed to fetch category progress" });
-    }
-  });
+    })
+  );
 
   const httpServer = createServer(app);
   return httpServer;

--- a/server/utils/asyncHandler.ts
+++ b/server/utils/asyncHandler.ts
@@ -1,0 +1,11 @@
+import type { Request, Response, NextFunction } from "express";
+
+export function asyncHandler<
+  T extends (req: Request, res: Response, next: NextFunction) => Promise<any>
+>(fn: T) {
+  return function (req: Request, res: Response, next: NextFunction): void {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+export default asyncHandler;


### PR DESCRIPTION
## Summary
- create reusable asyncHandler utility to forward async route errors
- refactor all server routes to use asyncHandler and let global middleware process errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: sh: 1: next: not found)
- `npm install` (fails: unable to resolve dependency tree)


------
https://chatgpt.com/codex/tasks/task_e_68bb39350a10832ea1417d349920eef9