### PR TITLE
localize game pages with i18n keys

### DIFF
--- a/client/src/i18n/nl.json
+++ b/client/src/i18n/nl.json
@@ -29,7 +29,18 @@
     "not_yet": "Nog niet",
     "next_card": "Volgende kaart",
     "well_done": "Goed gedaan!",
-    "review_complete": "Herziening voltooid!"
+    "review_complete": "Herziening voltooid!",
+    "tap_to_reveal": "Tik om te onthullen",
+    "what_does_mean": "Wat betekent dit?",
+    "means": "betekent",
+    "did_you_know": "Wist je dit?",
+    "fantastic": "Fantastisch!",
+    "great_job": "Goed gedaan!",
+    "its_okay": "Geeft niet!",
+    "keep_practicing": "Blijf oefenen!",
+    "no_words_title": "Geen woorden beschikbaar",
+    "no_words_message": "Geen woorden gevonden. Probeer het later opnieuw.",
+    "tip": "Tip: Probeer het woord hardop te zeggen voordat je de kaart omdraait!"
   },
   "memory": {
     "title": "Memory Game",
@@ -37,7 +48,11 @@
     "attempts": "Pogingen",
     "pairs_found": "Paren gevonden",
     "great_job": "Geweldig gedaan!",
-    "play_again": "Opnieuw spelen"
+    "play_again": "Opnieuw spelen",
+    "find_all_pairs": "Vind alle bijpassende paren!",
+    "new_game": "Nieuw spel",
+    "fantastic": "Fantastisch!",
+    "found_all_pairs": "Je vond alle {matches} paren in {attempts} pogingen!"
   },
   "quiz": {
     "title": "Quiz",
@@ -48,7 +63,17 @@
     "incorrect": "Niet juist",
     "final_score": "Eindresultaat",
     "well_done": "Goed gedaan!",
-    "try_again": "Probeer opnieuw"
+    "try_again": "Probeer opnieuw",
+    "not_enough_words": "Niet genoeg woorden voor een quiz. Leer eerst meer woorden!",
+    "score": "Score",
+    "what_does_mean": "Wat betekent dit in het Nederlands?",
+    "not_quite": "Niet helemaal!",
+    "correct_answer": "\"{spanish}\" betekent \"{dutch}\"",
+    "completed": "Quiz voltooid!",
+    "outstanding": "Uitstekend! Je bent een Spaanse superster!",
+    "great_job_message": "Goed gedaan! Blijf oefenen om nog beter te worden!",
+    "good_effort": "Goed geprobeerd! Oefening baart kunst!",
+    "take_again": "Quiz opnieuw doen"
   },
   "pronunciation": {
     "title": "Uitspraak Oefening",

--- a/client/src/pages/flashcards.tsx
+++ b/client/src/pages/flashcards.tsx
@@ -91,7 +91,7 @@ export default function Flashcards() {
 
   if (isLoading) {
     return (
-      <GameLayout title={t('loading')} color="coral">
+      <GameLayout title={t('common.loading')} color="coral">
         <div className="flex justify-center items-center h-64">
           <div className="animate-spin w-8 h-8 border-2 border-coral border-t-transparent rounded-full"></div>
         </div>
@@ -101,10 +101,10 @@ export default function Flashcards() {
 
   if (!currentWord) {
     return (
-      <GameLayout title="No Words Available" color="coral">
+      <GameLayout title={t('flashcards.no_words_title')} color="coral">
         <div className="text-center">
           <p className="font-nunito text-lg text-gray-600">
-            No vocabulary words found. Please try again later.
+            {t('flashcards.no_words_message')}
           </p>
         </div>
       </GameLayout>
@@ -278,7 +278,7 @@ export default function Flashcards() {
             variant="outline"
             className="rounded-2xl px-6 py-3"
           >
-            Previous
+            {t('common.previous')}
           </Button>
           
           <div className="flex space-x-2">
@@ -297,7 +297,7 @@ export default function Flashcards() {
             variant="outline"
             className="rounded-2xl px-6 py-3"
           >
-            Next
+            {t('common.next')}
           </Button>
         </div>
 
@@ -310,7 +310,7 @@ export default function Flashcards() {
         >
           <p className="font-nunito text-lg text-friendly-dark flex items-center">
             <Lightbulb className="text-sunny mr-2 w-5 h-5" />
-            Tip: Try to say the word out loud before flipping the card!
+            {t('flashcards.tip')}
           </p>
         </motion.div>
       </div>

--- a/client/src/pages/memory-game.tsx
+++ b/client/src/pages/memory-game.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { getRandomCharacter } from "@/lib/characters";
 import { audioManager } from "@/lib/audio";
 import { apiRequest } from "@/lib/queryClient";
-import { useTranslation } from "@/lib/i18n";
+import { useTranslation, interpolate } from "@/lib/i18n";
 import type { VocabularyWord } from "@shared/schema";
 
 const DEFAULT_USER_ID = "default_user";
@@ -158,7 +158,7 @@ export default function MemoryGame() {
 
   if (isLoading) {
     return (
-      <GameLayout title="Loading Memory Game..." color="mint">
+      <GameLayout title={t('common.loading')} color="mint">
         <div className="flex justify-center items-center h-64">
           <div className="animate-spin w-8 h-8 border-2 border-mint border-t-transparent rounded-full"></div>
         </div>
@@ -168,8 +168,8 @@ export default function MemoryGame() {
 
   return (
     <GameLayout
-      title="Memory Game"
-      subtitle="Match Spanish words with their pictures!"
+      title={t('memory.title')}
+      subtitle={t('memory.subtitle')}
       color="mint"
     >
       <div className="max-w-4xl mx-auto">
@@ -184,7 +184,7 @@ export default function MemoryGame() {
             <div className="font-comic text-friendly-dark">
               <p className="text-sm">{character.catchphrase}</p>
               <p className="text-xs text-gray-600">
-                Find all the matching pairs! Matches: {matches}/6 | Attempts: {attempts}
+                {t('memory.find_all_pairs')} {t('memory.pairs_found')}: {matches}/6 | {t('memory.attempts')}: {attempts}
               </p>
             </div>
           </div>
@@ -254,11 +254,11 @@ export default function MemoryGame() {
         <div className="flex justify-center items-center space-x-8 mb-6">
           <div className="flex items-center space-x-2">
             <Star className="text-sunny w-5 h-5" />
-            <span className="font-nunito font-bold">Matches: {matches}/6</span>
+            <span className="font-nunito font-bold">{t('memory.pairs_found')}: {matches}/6</span>
           </div>
           <div className="flex items-center space-x-2">
             <Trophy className="text-coral w-5 h-5" />
-            <span className="font-nunito font-bold">Attempts: {attempts}</span>
+            <span className="font-nunito font-bold">{t('memory.attempts')}: {attempts}</span>
           </div>
         </div>
 
@@ -270,7 +270,7 @@ export default function MemoryGame() {
             className="rounded-2xl px-6 py-3 flex items-center space-x-2"
           >
             <RotateCcw className="w-4 h-4" />
-            <span>New Game</span>
+            <span>{t('memory.new_game')}</span>
           </Button>
         </div>
 
@@ -291,24 +291,24 @@ export default function MemoryGame() {
               >
                 <div className="text-6xl mb-4">🎉</div>
                 <h3 className="font-fredoka text-3xl text-friendly-dark mb-4">
-                  ¡Fantástico!
+                  {t('memory.fantastic')}
                 </h3>
                 <p className="font-nunito text-lg text-gray-600 mb-6">
-                  You found all {matches} pairs in {attempts} attempts!
+                  {interpolate(t('memory.found_all_pairs'), { matches, attempts })}
                 </p>
                 <div className="space-y-3">
                   <Button
                     onClick={resetGame}
                     className="bg-mint text-white font-bold py-3 px-8 rounded-2xl w-full"
                   >
-                    Play Again
+                    {t('memory.play_again')}
                   </Button>
                   <Button
                     onClick={() => setGameCompleted(false)}
                     variant="outline"
                     className="rounded-2xl py-3 px-8 w-full"
                   >
-                    Close
+                    {t('common.close')}
                   </Button>
                 </div>
               </motion.div>

--- a/client/src/pages/quiz.tsx
+++ b/client/src/pages/quiz.tsx
@@ -10,7 +10,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { getRandomCharacter } from "@/lib/characters";
 import { audioManager } from "@/lib/audio";
 import { apiRequest } from "@/lib/queryClient";
-import { useTranslation } from "@/lib/i18n";
+import { useTranslation, interpolate } from "@/lib/i18n";
 import type { VocabularyWord } from "@shared/schema";
 
 const DEFAULT_USER_ID = "default_user";
@@ -125,7 +125,7 @@ export default function Quiz() {
 
   if (isLoading) {
     return (
-      <GameLayout title="Loading Quiz..." color="sunny">
+      <GameLayout title={t('common.loading')} color="sunny">
         <div className="flex justify-center items-center h-64">
           <div className="animate-spin w-8 h-8 border-2 border-sunny border-t-transparent rounded-full"></div>
         </div>
@@ -135,10 +135,10 @@ export default function Quiz() {
 
   if (questions.length === 0) {
     return (
-      <GameLayout title="Quiz" color="sunny">
+      <GameLayout title={t('quiz.title')} color="sunny">
         <div className="text-center">
           <p className="font-nunito text-lg text-gray-600">
-            Not enough vocabulary words for a quiz. Please learn more words first!
+            {t('quiz.not_enough_words')}
           </p>
         </div>
       </GameLayout>
@@ -147,8 +147,8 @@ export default function Quiz() {
 
   return (
     <GameLayout
-      title="Fun Quiz"
-      subtitle="Test your Spanish knowledge!"
+      title={t('quiz.title')}
+      subtitle={t('quiz.subtitle')}
       currentQuestion={currentQuestionIndex + 1}
       totalQuestions={questions.length}
       color="sunny"
@@ -165,7 +165,7 @@ export default function Quiz() {
             <div className="font-comic text-friendly-dark">
               <p className="text-sm">{character.catchphrase}</p>
               <p className="text-xs text-gray-600">
-                Score: {score}/{currentQuestionIndex + (showResult ? 1 : 0)}
+                {t('quiz.score')}: {score}/{currentQuestionIndex + (showResult ? 1 : 0)}
               </p>
             </div>
           </div>
@@ -183,7 +183,7 @@ export default function Quiz() {
               {/* Question */}
               <div className="text-center mb-8">
                 <h4 className="font-fredoka text-3xl text-friendly-dark mb-6">
-                  What does this mean in Dutch?
+                  {t('quiz.what_does_mean')}
                 </h4>
                 
                 {/* Question Word */}
@@ -256,15 +256,15 @@ export default function Quiz() {
                     {selectedAnswer === currentQuestion.correctAnswer.id ? (
                       <div className="bg-success/20 rounded-2xl p-6">
                         <div className="text-4xl mb-2">🎉</div>
-                        <h3 className="font-fredoka text-2xl text-success mb-2">¡Correcto!</h3>
-                        <p className="font-nunito text-friendly-dark">Excellent work!</p>
+                        <h3 className="font-fredoka text-2xl text-success mb-2">{t('quiz.correct')}</h3>
+                        <p className="font-nunito text-friendly-dark">{t('feedback.excellent')}</p>
                       </div>
                     ) : (
                       <div className="bg-red-500/20 rounded-2xl p-6">
                         <div className="text-4xl mb-2">📚</div>
-                        <h3 className="font-fredoka text-2xl text-red-500 mb-2">Not quite!</h3>
+                        <h3 className="font-fredoka text-2xl text-red-500 mb-2">{t('quiz.not_quite')}</h3>
                         <p className="font-nunito text-friendly-dark">
-                          "{currentQuestion.word.spanish}" means "{currentQuestion.correctAnswer.dutch}"
+                          {interpolate(t('quiz.correct_answer'), { spanish: currentQuestion.word.spanish, dutch: currentQuestion.correctAnswer.dutch })}
                         </p>
                       </div>
                     )}
@@ -283,16 +283,16 @@ export default function Quiz() {
                 <div className="text-8xl mb-6">
                   {score >= questions.length * 0.8 ? "🏆" : score >= questions.length * 0.6 ? "🌟" : "📚"}
                 </div>
-                
+
                 <h2 className="font-fredoka text-4xl text-friendly-dark mb-4">
-                  ¡Quiz Completado!
+                  {t('quiz.completed')}
                 </h2>
                 
                 <div className="flex items-center justify-center space-x-6 mb-6">
                   <div className="flex items-center space-x-2">
                     <Star className="text-sunny w-6 h-6" />
                     <span className="font-nunito text-xl font-bold">
-                      Score: {score}/{questions.length}
+                      {t('quiz.score')}: {score}/{questions.length}
                     </span>
                   </div>
                   <div className="flex items-center space-x-2">
@@ -304,12 +304,11 @@ export default function Quiz() {
                 </div>
 
                 <p className="font-nunito text-lg text-gray-600 mb-8">
-                  {score >= questions.length * 0.8 
-                    ? "Outstanding! You're a Spanish superstar!" 
+                  {score >= questions.length * 0.8
+                    ? t('quiz.outstanding')
                     : score >= questions.length * 0.6
-                    ? "Great job! Keep practicing to improve even more!"
-                    : "Good effort! Practice makes perfect!"
-                  }
+                    ? t('quiz.great_job_message')
+                    : t('quiz.good_effort')}
                 </p>
 
                 <Button
@@ -317,7 +316,7 @@ export default function Quiz() {
                   className="bg-sunny text-white font-bold py-4 px-8 rounded-2xl flex items-center space-x-2 mx-auto"
                 >
                   <RotateCcw className="w-5 h-5" />
-                  <span>Take Quiz Again</span>
+                  <span>{t('quiz.take_again')}</span>
                 </Button>
               </div>
             </motion.div>


### PR DESCRIPTION
## Summary
- replace hardcoded text in flashcards, memory game, and quiz pages with translation lookups
- expand Dutch i18n file with keys for game prompts and messages
- add interpolation helper usage for dynamic quiz and memory messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bb393cae1c832ea55664cc330a5d4b