### PR TITLE
Add typed SpeechRecognition interfaces

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,4 +25,3 @@
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }
-}


### PR DESCRIPTION
## Summary
- define Web Speech API interfaces and augment `window` for recognition and audio context
- replace `any` usages in audio manager with typed SpeechRecognition events
- fix malformed `tsconfig.json` closing brace

## Testing
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@/components/audio-button' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb393cce84832eb79cefeaa905984e