### PR TITLE
refactor: centralize default user id

### DIFF
--- a/client/src/components/boss-quiz.tsx
+++ b/client/src/components/boss-quiz.tsx
@@ -15,8 +15,7 @@ import { audioManager } from "@/lib/audio";
 import { apiRequest } from "@/lib/queryClient";
 import { SPANISH_VOCABULARY, getRandomWords } from "@/data/spanish-vocabulary";
 import type { VocabularyWord } from "@shared/schema";
-
-const DEFAULT_USER_ID = "default_user";
+import { DEFAULT_USER_ID } from "../lib/constants";
 
 interface BossQuizQuestion {
   word: VocabularyWord;

--- a/client/src/components/comprehensive-flashcards.tsx
+++ b/client/src/components/comprehensive-flashcards.tsx
@@ -12,8 +12,7 @@ import { audioManager } from "@/lib/audio";
 import { apiRequest } from "@/lib/queryClient";
 import { SPANISH_VOCABULARY, getRandomWords } from "@/data/spanish-vocabulary";
 import type { VocabularyWord } from "@/data/spanish-vocabulary";
-
-const DEFAULT_USER_ID = "default_user";
+import { DEFAULT_USER_ID } from "../lib/constants";
 
 interface FlashcardSessionProps {
   category?: string;

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -4,8 +4,7 @@ import { Star, Settings, Home, BookOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "@/lib/i18n";
 import type { UserStats } from "@shared/schema";
-
-const DEFAULT_USER_ID = "default_user";
+import { DEFAULT_USER_ID } from "../lib/constants";
 
 export function Navigation() {
   const [location] = useLocation();

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_USER_ID = "default_user";

--- a/client/src/pages/flashcards.tsx
+++ b/client/src/pages/flashcards.tsx
@@ -12,8 +12,7 @@ import { audioManager } from "@/lib/audio";
 import { apiRequest } from "@/lib/queryClient";
 import { useTranslation } from "@/lib/i18n";
 import type { VocabularyWord } from "@shared/schema";
-
-const DEFAULT_USER_ID = "default_user";
+import { DEFAULT_USER_ID } from "../lib/constants";
 
 export default function Flashcards() {
   const { t } = useTranslation();

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -10,8 +10,7 @@ import { useTranslation } from "@/lib/i18n";
 import { CHARACTERS } from "@/lib/characters";
 import { VOCABULARY_CATEGORIES, getCategoryColor } from "@/lib/vocabulary";
 import type { UserStats } from "@shared/schema";
-
-const DEFAULT_USER_ID = "default_user";
+import { DEFAULT_USER_ID } from "../lib/constants";
 
 interface CategoryProgress {
   name: string;

--- a/client/src/pages/memory-game.tsx
+++ b/client/src/pages/memory-game.tsx
@@ -11,8 +11,7 @@ import { audioManager } from "@/lib/audio";
 import { apiRequest } from "@/lib/queryClient";
 import { useTranslation } from "@/lib/i18n";
 import type { VocabularyWord } from "@shared/schema";
-
-const DEFAULT_USER_ID = "default_user";
+import { DEFAULT_USER_ID } from "../lib/constants";
 
 interface MemoryCard {
   id: string;

--- a/client/src/pages/pronunciation.tsx
+++ b/client/src/pages/pronunciation.tsx
@@ -12,8 +12,7 @@ import { audioManager } from "@/lib/audio";
 import { apiRequest } from "@/lib/queryClient";
 import { useTranslation } from "@/lib/i18n";
 import type { VocabularyWord } from "@shared/schema";
-
-const DEFAULT_USER_ID = "default_user";
+import { DEFAULT_USER_ID } from "../lib/constants";
 
 export default function Pronunciation() {
   const { t } = useTranslation();

--- a/client/src/pages/quiz.tsx
+++ b/client/src/pages/quiz.tsx
@@ -12,8 +12,7 @@ import { audioManager } from "@/lib/audio";
 import { apiRequest } from "@/lib/queryClient";
 import { useTranslation } from "@/lib/i18n";
 import type { VocabularyWord } from "@shared/schema";
-
-const DEFAULT_USER_ID = "default_user";
+import { DEFAULT_USER_ID } from "../lib/constants";
 
 interface QuizQuestion {
   word: VocabularyWord;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -9,6 +9,7 @@ import {
   type InsertUserStats
 } from "@shared/schema";
 import { randomUUID } from "crypto";
+import { DEFAULT_USER_ID } from "../client/src/lib/constants";
 
 export interface IStorage {
   // Vocabulary methods
@@ -171,7 +172,7 @@ export class MemStorage implements IStorage {
       ...insertSession, 
       id,
       duration: insertSession.duration || 0,
-      userId: insertSession.userId || "default_user",
+      userId: insertSession.userId || DEFAULT_USER_ID,
       score: insertSession.score || 0,
       totalQuestions: insertSession.totalQuestions || 0,
       correctAnswers: insertSession.correctAnswers || 0,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import { pgTable, text, varchar, integer, boolean, jsonb } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
+import { DEFAULT_USER_ID } from "../client/src/lib/constants";
 
 export const vocabularyWords = pgTable("vocabulary_words", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
@@ -15,7 +16,7 @@ export const vocabularyWords = pgTable("vocabulary_words", {
 
 export const userProgress = pgTable("user_progress", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull().default("default_user"),
+  userId: varchar("user_id").notNull().default(DEFAULT_USER_ID),
   wordId: varchar("word_id").notNull(),
   timesCorrect: integer("times_correct").notNull().default(0),
   timesIncorrect: integer("times_incorrect").notNull().default(0),
@@ -25,7 +26,7 @@ export const userProgress = pgTable("user_progress", {
 
 export const gameSession = pgTable("game_session", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull().default("default_user"),
+  userId: varchar("user_id").notNull().default(DEFAULT_USER_ID),
   gameType: text("game_type").notNull(),
   score: integer("score").notNull().default(0),
   totalQuestions: integer("total_questions").notNull().default(0),
@@ -36,7 +37,7 @@ export const gameSession = pgTable("game_session", {
 
 export const spacedRepetitionItems = pgTable("spaced_repetition_items", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull().default("default_user"),
+  userId: varchar("user_id").notNull().default(DEFAULT_USER_ID),
   wordId: varchar("word_id").notNull(),
   level: integer("level").notNull().default(0), // 0-6 spaced repetition level
   nextDue: text("next_due").notNull(),
@@ -48,7 +49,7 @@ export const spacedRepetitionItems = pgTable("spaced_repetition_items", {
 
 export const achievements = pgTable("achievements", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull().default("default_user"),
+  userId: varchar("user_id").notNull().default(DEFAULT_USER_ID),
   achievementType: text("achievement_type").notNull(),
   category: text("category"),
   unlockedAt: text("unlocked_at").notNull(),
@@ -57,7 +58,7 @@ export const achievements = pgTable("achievements", {
 
 export const userStats = pgTable("user_stats", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull().default("default_user"),
+  userId: varchar("user_id").notNull().default(DEFAULT_USER_ID),
   totalStars: integer("total_stars").notNull().default(0),
   currentStreak: integer("current_streak").notNull().default(0),
   longestStreak: integer("longest_streak").notNull().default(0),


### PR DESCRIPTION
## Summary
- add DEFAULT_USER_ID constant
- use DEFAULT_USER_ID across client pages, components, schema and storage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: tsconfig.json(28,1): error TS1012: Unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bb39394598832ea63cc517c964faed