### PR TITLE
Add dynamic category lookup in API

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "^5.9.2",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^3.2.4"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -107,7 +107,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const allWords = await storage.getVocabularyWords();
       const userProgress = await storage.getUserProgress(userId);
       
-      const categories = ["greetings", "numbers_1_10", "colors", "animals", "food", "family", "body_parts", "weather"];
+      const categories = await storage.getCategories();
       const categoryProgress = categories.map(category => {
         const categoryWords = allWords.filter(word => word.category === category);
         const completedWords = categoryWords.filter(word => 

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { storage } from './storage';
+
+// Wait for asynchronous vocabulary initialization
+async function waitForInit() {
+  // give initializeVocabulary time to populate map
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('storage.getCategories', () => {
+  it('returns unique vocabulary categories', async () => {
+    await waitForInit();
+    const categories = await storage.getCategories();
+    expect(categories.length).toBeGreaterThan(0);
+    const unique = new Set(categories);
+    expect(unique.size).toBe(categories.length);
+    expect(categories).toContain('greetings');
+  });
+});

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16,6 +16,7 @@ export interface IStorage {
   getVocabularyWordsByCategory(category: string): Promise<VocabularyWord[]>;
   getVocabularyWord(id: string): Promise<VocabularyWord | undefined>;
   createVocabularyWord(word: InsertVocabularyWord): Promise<VocabularyWord>;
+  getCategories(): Promise<string[]>;
   
   // User progress methods
   getUserProgress(userId: string): Promise<UserProgress[]>;
@@ -114,8 +115,8 @@ export class MemStorage implements IStorage {
 
   async createVocabularyWord(insertWord: InsertVocabularyWord): Promise<VocabularyWord> {
     const id = randomUUID();
-    const word: VocabularyWord = { 
-      ...insertWord, 
+    const word: VocabularyWord = {
+      ...insertWord,
       id,
       imageUrl: insertWord.imageUrl || null,
       audioUrl: insertWord.audioUrl || null,
@@ -123,6 +124,12 @@ export class MemStorage implements IStorage {
     };
     this.vocabularyWords.set(id, word);
     return word;
+  }
+
+  async getCategories(): Promise<string[]> {
+    return Array.from(
+      new Set(Array.from(this.vocabularyWords.values()).map((word) => word.category))
+    );
   }
 
   async getUserProgress(userId: string): Promise<UserProgress[]> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,4 +25,3 @@
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }
-}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+});


### PR DESCRIPTION
## Summary
- derive unique category list from vocabulary and expose via `storage.getCategories`
- use the new `getCategories` method in the `/api/categories/:userId` route
- add unit test and vitest config for category retrieval

## Testing
- `npm test` *(fails: Missing script)*
- `npx vitest run --config vitest.config.ts` *(fails: SpacedRepetition tests)*
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bb393669bc832eaa230d559aea1dc8