### PR TITLE
chore: update react-day-picker for React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "passport-local": "^1.0.0",
     "prettier": "^3.6.2",
     "react": "^19.1.1",
-    "react-day-picker": "^8.10.1",
+    "react-day-picker": "^9.9.0",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.55.0",
     "react-icons": "^5.4.0",


### PR DESCRIPTION
## Summary
- update react-day-picker to version compatible with React 19

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: tsconfig.json(28,1): error TS1012: Unexpected token.)*
- `npm run build` *(fails: tsconfig.json(28,1): error TS1012: Unexpected token.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3f18af40832e825588b31c3e847c