### PR TITLE
fix: remove stray closing brace in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,4 +25,3 @@
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }
-}


### PR DESCRIPTION
## Summary
- fix syntax error in tsconfig.json by removing an extra closing brace

## Testing
- `npm run lint` (fails: next not found)
- `npm run build` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_68bb4c1305bc832ea1022c5a25dbbc2a